### PR TITLE
chore: bump grafanaDependency to >=10.4.8 to enable PDC support

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -42,7 +42,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=10.0.0",
+    "grafanaDependency": ">=10.4.8",
     "plugins": []
   }
 }


### PR DESCRIPTION
## What
Bump the minimum Grafana dependency to 10.4.8 in src/plugin.json.

## Why
Grafana 10.4.8 introduced the Private Data Source Connect UI and SDK support,
so we need to raise our minimum to allow users to select PDC in the Vertica data source.

## Validation
- `yarn lint` ran cleanly.
- `yarn build` succeeded without errors.